### PR TITLE
changed the layout of the collab index. fixed the double received req…

### DIFF
--- a/app/assets/stylesheets/components/_collab-card.scss
+++ b/app/assets/stylesheets/components/_collab-card.scss
@@ -68,8 +68,9 @@
 .container-collab-image img {
   display: block;
   margin: auto;
-  max-width: 400px;
-  max-height: 600px;
+  width: 400px;
+  max-height: 533px;
+  pointer-events: none;
 }
 
 .collab-card-members-todo {
@@ -172,7 +173,7 @@
 
     h3 {
       margin-bottom: 0;
-      width: 200px;
+      width: 250px;
 
       a {
         color: inherit;
@@ -201,12 +202,16 @@
     }
 
     .founder {
-      width: 150px;
+      width: 200px;
     }
 
     .request-not-accepted-yet {
       width: 300px;
       text-align: center;
+    }
+
+    .btn-outline-primary {
+      margin-bottom: 0;
     }
   }
 
@@ -246,7 +251,7 @@
     }
 
     .founder {
-      width: 150px;
+      width: 200px;
     }
   }
 }

--- a/app/views/collabs/index.html.erb
+++ b/app/views/collabs/index.html.erb
@@ -19,30 +19,22 @@
   </div>
   <br>
   <br>
-  <div class="container-collab-cards">
-    <% @collabs.each do |collab| %>
-      <div class="collab-card">
-        <% if collab.photo.attached? %>
-          <%= link_to image_tag(collab.photo), collab_path(collab.id), crop: :fill %>
-        <% else %>
-          <%= link_to image_tag('artist_2.png'), collab_path(collab.id) %>
-        <% end %>
-
-        <div class="collab-card-infos">
-          <% if collab.users.include? current_user %>
-           <h3><%= link_to collab.name, collab_path(collab.id) %></h3>
-            <% else %>
-             <h3><%= collab.name %></h3>
-          <% end %>
-          <h4><%= collab.description %></h4>
-          <% unless collab.users.include? current_user  %>
-            <div class="btn-collab-card">
-              <%= link_to "Ask to join this collab", user_collab_relationships_path(user_collab_relationship: {collab_id: collab.id, user_id: current_user.id, status: "pending" }), method: :post , class: 'btn btn-outline-primary' %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-  </div>
   <br>
+  <br>
+  <div class="container">
+    <% @collabs.each do |collab| %>
+    <% unless collab.users.include?(current_user) %>
+    <div class="collab-list-infos">
+      <h3><%= collab.name %></h3>
+      <h4><%= collab.description %></h4>
+      <p class="founder"> Created by <u><%= collab.users.first.username %></u> </p>
+      <div class="btn-collab-card">
+        <%= link_to "Ask to join this collab", user_collab_relationships_path(user_collab_relationship: {collab_id: collab.id, user_id: current_user.id, status: "pending" }), method: :post , class: 'btn btn-outline-primary' %>
+      </div>
+    </div>
+    <hr class="divider">
+    <% end %>
+  <% end %>
+  </div>
 </div>
+<br>

--- a/app/views/user_collab_relationships/index.html.erb
+++ b/app/views/user_collab_relationships/index.html.erb
@@ -37,13 +37,16 @@
       <% end %>
       <br>
       <br>
+    <div class="collab-active-and-requests">
+      <h2>Received requests</h2>
+    </div>
+    <br>
+    <br>
+    <br>
+      <% if @collabs_to_accept.empty? %>
+        <h3 style="text-align: center;"> You haven't received any request. </h3>
+      <% end %>
       <% @collabs_to_accept.each do |cr| %>
-      <div class="collab-active-and-requests">
-        <h2>Received requests</h2>
-      </div>
-      <br>
-      <br>
-      <br>
         <div class="collab-request-infos">
           <h3> <%= link_to cr.collab.name, collab_path(cr.collab_id) %> </h3>
           <h4> <%= cr.collab.description %> </h4>


### PR DESCRIPTION
…uest. deleted the divider when accept/reject. added a sentence when there is no received request.

<img width="1552" alt="Screenshot 2021-02-24 at 15 17 43" src="https://user-images.githubusercontent.com/68268413/109015963-f6667500-76b5-11eb-842f-5b275176f494.png">

Also now, the "collab index" shows only the collab you're not member of. The ones you're part of and the ones you have created are in "My Collabs"
